### PR TITLE
Fix link previews

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,19 +1,44 @@
 <head>
 	{% assign title = "" %}
 	{% assign description = "" %}
+	{% assign ogtype = "website" %}
 	
 	{%- if page.description -%}
 		{% assign title = page.title %}
 		{% assign description = page.description %}
+		{% assign ogtype = "article" %}
 	{%- else -%}
 		{% assign title = site.title %}
 		{% assign description = site.description %}
 	{%- endif -%}
 	
+	
+	{% assign image = site.author.image %}
+	{%- if page.image -%}
+		{% assign image = page.image | remove_first: ".." %}
+	{%- endif -%}
+	
+	
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="{{ description }}">
+	
+	<meta property="og:locale" content="en_US">
+	<meta property="og:type" content="{{ ogtype }}">
+	<meta property="og:title" content="{{ title }}">
+	<meta property="og:description" content="{{ description }}">
+	<meta property="og:url" content="{{ site.url | append: page.url }}">
+	<meta property="og:site_name" content="{{ site.author.name }}">
+	<meta property="og:image" content="{{ site.url | append: image }}">
+	
+	<meta name="twitter:card" content="content">
+	<meta name="twitter:title" content="{{ title }}">
+	<meta name="twitter:description" content="{{ description }}">
+	<meta name="twitter:site" content="{{'@' | append: site.author.twitter }}">
+	<meta name="twitter:image" content="{{ site.url | append: image }}">
+	<meta name="twitter:creator" content="{{'@' | append: site.author.twitter }}">
+	
 
 	<title>{{ title }}</title>
 	<link rel="shortcut icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,33 @@
+<head>
+	{% assign title = "" %}
+	{% assign description = "" %}
+	
+	{%- if page.description -%}
+		{% assign title = page.title %}
+		{% assign description = page.description %}
+	{%- else -%}
+		{% assign title = site.title %}
+		{% assign description = site.description %}
+	{%- endif -%}
+	
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="description" content="{{ description }}">
+
+	<title>{{ title }}</title>
+	<link rel="shortcut icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">
+
+	<!-- Font Awesome CDN -->
+	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.10.0/css/all.css">
+
+	<!-- Bootstrap CSS CDN -->
+	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+
+	<!-- Animate CSS CDN -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.css" type="text/css"/>
+
+	<!-- Custom CSS -->
+	<link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" type="text/css">
+
+</head>


### PR DESCRIPTION
Updated the head file to improve social media linking. Blog and project pages will now update the title and description with the page.title and page.description fields, and all pages now include social media meta tags to improve appearance across sites that support og and twitter cards. 