### PR TITLE
Adding RSS feeds for blog and projects pages. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'jekyll-feed'

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ remote_theme: YoussefRaafatNasry/portfolYOU
 #markdown: kramdown
 plugins:
   - jemoji
+  - jekyll-feed
 
 ### Navbar Settings ###
 nav_exclude:                                            # The following paths are excluded from navbar

--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,14 @@ defaults:
 permalink: blog/:title
 
 
+feed:
+    tags: true 
+    collections:
+        projects:
+            path: "/feed/projects.xml"
+        posts:
+            path: "/feed/blog.xml"
+
 # Exclude from processing.
 exclude:
 - README.md


### PR DESCRIPTION
Using Jekyll-Feed to automatically create an RSS feed for both blog posts (/feed/blog.xml) and projects (/feed/projects.xml). 